### PR TITLE
Npm audit flag (1.3.2 hotfix)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "dgtlss/warden",
     "description": "A Laravel package that proactively monitors your dependencies for security vulnerabilities by running automated composer audits and sending notifications via webhooks and email",
     "keywords": ["laravel", "composer", "security", "vulnerabilities", "audits", "notifications", "CVE"],
-    "version": "1.3.1",
+    "version": "1.3.2",
     "license": "MIT",
     "autoload": {
         "psr-4": {

--- a/src/Services/Audits/NpmAuditService.php
+++ b/src/Services/Audits/NpmAuditService.php
@@ -36,34 +36,84 @@ class NpmAuditService extends AbstractAuditService
         }
 
         $process = new Process(['npm', 'audit', '--json']);
-        $process->run();
+        $process->setWorkingDirectory(base_path());
+        $process->setTimeout(config('warden.audits.timeout', 300));
 
-        if (!$process->isSuccessful()) {
+        try {
+            $process->run();
+            
+            // npm audit returns non-zero exit codes when vulnerabilities are found, which is normal
+            // Only treat it as an error if we can't parse the JSON output
+            $output = json_decode($process->getOutput(), true);
+            if ($output === null) {
+                $errorOutput = $process->getErrorOutput() ?: $process->getOutput() ?: 'No error output available';
+                $exitCode = $process->getExitCode();
+                
+                $this->addFinding([
+                    'package' => 'npm',
+                    'title' => 'npm audit failed to run',
+                    'severity' => 'high',
+                    'cve' => null,
+                    'affected_versions' => null,
+                    'error' => "Exit Code: {$exitCode}\nError: {$errorOutput}"
+                ]);
+                return false;
+            }
+
+            // Handle modern npm audit format (npm 7+)
+            if (isset($output['vulnerabilities'])) {
+                foreach ($output['vulnerabilities'] as $package => $vulnerability) {
+                    // Modern format has vulnerability details in the 'via' array
+                    if (isset($vulnerability['via']) && is_array($vulnerability['via'])) {
+                        foreach ($vulnerability['via'] as $viaItem) {
+                            // Skip string entries (they're just package names), process array entries
+                            if (is_array($viaItem)) {
+                                $this->addFinding([
+                                    'package' => $package,
+                                    'title' => $viaItem['title'] ?? 'Unknown vulnerability',
+                                    'severity' => $viaItem['severity'] ?? 'unknown',
+                                    'cve' => $viaItem['url'] ?? null,
+                                    'affected_versions' => $viaItem['range'] ?? ($vulnerability['range'] ?? 'unknown')
+                                ]);
+                            }
+                        }
+                    } else {
+                        // Fallback for potential legacy format or missing via array
+                        $this->addFinding([
+                            'package' => $package,
+                            'title' => $vulnerability['title'] ?? 'Unknown vulnerability',
+                            'severity' => $vulnerability['severity'] ?? 'unknown',
+                            'cve' => $vulnerability['url'] ?? null,
+                            'affected_versions' => $vulnerability['range'] ?? 'unknown'
+                        ]);
+                    }
+                }
+            }
+            
+            // Handle legacy npm audit format (npm v6 and earlier) - advisories format
+            if (isset($output['advisories'])) {
+                foreach ($output['advisories'] as $advisory) {
+                    $this->addFinding([
+                        'package' => $advisory['module_name'] ?? 'unknown',
+                        'title' => $advisory['title'] ?? 'Unknown vulnerability',
+                        'severity' => $advisory['severity'] ?? 'unknown',
+                        'cve' => $advisory['cves'][0] ?? $advisory['url'] ?? null,
+                        'affected_versions' => $advisory['vulnerable_versions'] ?? 'unknown'
+                    ]);
+                }
+            }
+
+            return true;
+        } catch (\Exception $e) {
             $this->addFinding([
                 'package' => 'npm',
-                'title' => 'npm audit command failed',
-                'severity' => 'error',
+                'title' => 'npm audit failed with exception',
+                'severity' => 'high',
                 'cve' => null,
                 'affected_versions' => null,
-                'details' => $process->getErrorOutput() ?: 'No error output available'
+                'error' => $e->getMessage()
             ]);
             return false;
         }
-
-        $output = json_decode($process->getOutput(), true);
-        
-        if (isset($output['vulnerabilities'])) {
-            foreach ($output['vulnerabilities'] as $package => $vuln) {
-                $this->addFinding([
-                    'package' => $package,
-                    'title' => $vuln['title'] ?? 'Unknown',
-                    'severity' => $vuln['severity'] ?? 'unknown',
-                    'cve' => $vuln['url'] ?? null,
-                    'affected_versions' => $vuln['range'] ?? 'unknown'
-                ]);
-            }
-        }
-
-        return true;
     }
 }


### PR DESCRIPTION
### What This Fixes:

  - ✅ Resolves the "npm audit failed to run" error when using `php artisan warden:audit --npm`
  - ✅ Properly parses and reports npm vulnerabilities in modern npm versions
  - ✅ Maintains compatibility with existing users (no breaking changes)
  - ✅ Uses GitHub Advisory URLs instead of direct CVE references (as per modern npm)
  - ✅ Handles both modern npm 7+ format and legacy npm 6 format