### PR TITLE
Improve suspicious string literals/secrets audit

### DIFF
--- a/src/Services/Source/TextSourceAnalyzer.php
+++ b/src/Services/Source/TextSourceAnalyzer.php
@@ -59,7 +59,11 @@ final class TextSourceAnalyzer
                     continue 2;
                 }
 
-                if ($this->rulePolicy->enabled('source.secrets.suspicious-literal') && preg_match('/(?:password|secret|api_?key|access_?token|private_?key)["\']?\s*(?:=>|=)\s*["\']([^"\']{8,})["\']/i', $line, $match) === 1) {
+                if (
+                    $this->rulePolicy->enabled('source.secrets.suspicious-literal')
+                    && preg_match('/(?:password|secret|api_?key|access_?token|private_?key)["\']?\s*(?:=>|=)\s*["\']([^"\']{8,})["\']/i', $line, $match) === 1
+                    && $this->looksLikeCredential($match[1])
+                ) {
                     $findings[] = new Finding(
                         id: 'source.secrets.suspicious-literal',
                         source: 'source',
@@ -77,6 +81,17 @@ final class TextSourceAnalyzer
         }
 
         return $findings;
+    }
+
+    private function looksLikeCredential(string $value): bool
+    {
+        // Values with spaces or other symbols found in validation are likely not credentials
+        if (preg_match('/[\s|{}<>]/', $value) === 1) {
+            return false;
+        }
+
+        // Values not containing digits or symbols are likely not credentials
+        return preg_match('/^[A-Za-z]+(?:[_.\-][A-Za-z]+)*$/', $value) !== 1;
     }
 
     /**

--- a/tests/Services/Audits/SourceAuditServiceTest.php
+++ b/tests/Services/Audits/SourceAuditServiceTest.php
@@ -16,6 +16,7 @@ use Dgtlss\Warden\Reporters\SarifReporter;
 use Dgtlss\Warden\Tests\TestCase;
 use Dgtlss\Warden\ValueObjects\AuditContext;
 use Dgtlss\Warden\ValueObjects\AuditReport;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionProperty;
@@ -136,6 +137,32 @@ PHP);
         self::assertFalse($byId['source.blade.unescaped-output']->blocking);
         self::assertArrayNotHasKey('source.php.xss-tainted-output', $byId);
         self::assertArrayNotHasKey('source.php.command-tainted-input', $byId);
+    }
+
+    #[DataProvider('secretNamedLiteralProvider')]
+    public function testSecretNamedLiteralsAreJudgedOnTheirValue(string $value, bool $reported): void
+    {
+        $this->write('app/Credentials.php', sprintf("<?php\n\nreturn ['api_key' => '%s'];\n", $value));
+
+        $ids = array_map(static fn ($finding): string => $finding->id, $this->service()->run(new AuditContext())->findings);
+
+        self::assertSame($reported, in_array('source.secrets.suspicious-literal', $ids, true));
+    }
+
+    /** @return iterable<string, array{string, bool}> */
+    public static function secretNamedLiteralProvider(): iterable
+    {
+        yield 'hexadecimal api key' => ['43b38433ec597605e63c7e9d67c52539', true];
+        yield 'password using symbols and digits' => ['P@ssw0rd!longenough', true];
+        yield 'base64 encoded token' => ['aGVsbG9Xb3JsZFRoaXNJc0FTZWNyZXQ=', true];
+
+        yield 'translated sentence' => ['Het wachtwoord is niet correct', false];
+        yield 'validation rule' => ['required|min:3', false];
+        yield 'validation rule referencing another field' => ['required|same:password', false];
+        yield 'field name constant' => ['password', false];
+        yield 'cache key' => ['wekeo_access_token', false];
+        yield 'enum backing value' => ['invalid_access_token', false];
+        yield 'translation key' => ['password.reset', false];
     }
 
     public function testSecretsAreRedactedAndFingerprintsSurviveLineMovement(): void


### PR DESCRIPTION
### Problem 
I noticed that we got a lot of false positives with this check. `SourceAuditService` -> `TextSourceAnalyzer`

It flagged:
- `access_token` validation in the middleware: `access_token => 'required|min:3`'
- `password` validation in the middleware: `required|same:password`
- 'password' key in translation files
- key names with `%_access_token` in it

To name a few.

### Proposed solution
Also check the value of keys to (somewhat rudimentary) see if there are actually suspicious values. This way it removes all above false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of suspicious secret-like literals by checking the assigned value, reducing false positives for normal text, validation rules, field names, cache keys, enum values, and translation keys.
  * Continued identifying likely credentials such as hexadecimal keys, symbol-and-digit passwords, and Base64 tokens.

* **Tests**
  * Added coverage for credential detection and common non-secret values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->